### PR TITLE
Fix: added .gitignore in the root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin
+include
+lib
+lib64
+pyvenv.cfg


### PR DESCRIPTION
added .gitignore to prevent venv dir to show up in commits.

Highly recommended to use venv.